### PR TITLE
ENH: More liberal specification of TSV files

### DIFF
--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -524,13 +524,16 @@ The user is free to choose any other label than `singleband` and
 
 ### REQUIRED gradient strength and orientation information
 
-The REQUIRED gradient strength and orientation information corresponding to a DWI acquisition
-MUST be stored using `[*_]dwi.bval` and `[*_]dwi.bvec` pairs of files.
-In addition, it is RECOMMENDED to store the gradient orientation in a `[*_]dwi.tsv` file,
-in the *RASB+* format described below.
-The `[*_]dwi.[bval|bvec]` files are DEPRECATED and will be
+The gradient strength and orientation information corresponding to a DWI acquisition
+is REQUIRED, and therefore, MUST be stored in the structure.
+The RECOMMENDED way to store gradient information is a `[*_]dwi.tsv` file corresponding
+to one or more DWI files.
+The format of this TSV file, and associated metadata, are described below.
+The gradient information MAY be stored using the `[*_]dwi.bval` and `[*_]dwi.bvec` pair
+of files.
+However, the `[*_]dwi.[bval|bvec]` files are DEPRECATED and will be
 phased out in a future release.
-The *RASB+* file format is OPTIONAL and will replace `[*_]dwi.[bval|bvec]` as the
+The TSV file format is OPTIONAL, and will replace `[*_]dwi.[bval|bvec]` as the
 default method for representing gradients.
 
 The `[*_]dwi.[bval|bvec|tsv]` files MAY be saved on any level of the directory structure
@@ -541,7 +544,47 @@ As an exception to the [common principles](../02-common-principles.md#definition
 that parameters are constant across runs, the gradient table information (stored
 within `[*_]dwi.[bval|bvec|tsv]` files) MAY change across DWI runs.
 
-**BVEC/BVAL specification**.
+**Gradient table specification (`_dwi.tsv` file)**.
+Gradient strength and orientation can be provided in a TSV file named, for example,
+`sub-01_acq-singleband_dwi.tsv` or `sub-01_acq-multiband_dwi.tsv`.
+This TSV file must contain four columns, where the first three columns correspond to the
+three components of a unit-norm vector determining one gradient orientation (also called "*b*-vector")
+and the last column contains the gradient strength ("*b*-value") in s/mm<sup>2</sup>.
+Each row of the TSV file corresponds to one sampled DWI, and therefore, the number of rows
+MUST match the number of volumes in the corresponding DWI file(s).
+In other words, the number of rows in the TSV file and the size of the last dimension of the
+data array in the corresponding DWI file(s) MUST be the same.
+
+Rows corresponding to *b = 0* s/mm<sup>2</sup> strengths MUST contain four zeros.
+Correspondingly, the components of the *b*-vector corresponding to a nonzero gradient strength
+(*b* &#62; 0) MUST represent a unit-norm vector.
+
+Scanner devices may store the *b*-vectors with reference to the acquired voxel or the
+scanner coordinate system (see [Coordinate systems](../99-appendices/08-coordinate-systems.md)).
+The coordinate system specification is REQUIRED, and MUST be encoded by the column headers
+of the TSV file.
+Therefore, if the *b*-vectors in the gradient table are given in *voxel coordinates*,
+the column headers MUST be `I`, `J`, `K`, `b`.
+We will refer to this format as *IJK+b* in the following.
+Alternatively, if the *b*-vectors in the gradient table are given in *scanner coordinates*,
+the column headers MUST be `R`, `A`, `S`, `b`.
+We will refer to this format as *RAS+b* in the following.
+
+It is RECOMMENDED to store the gradient table information in the original coordinate system
+stored by the scanner (therefore, unchanged).
+It is RECOMMENDED to maintain the column ordering as described above (thus, either `I J K b`
+or `R A S b`).
+
+Example of `_dwi.tsv` file, following the *RAS+b* convention:
+
+```Text
+R	A	S	b
+0	0	0	0
+1.0	0	0	1000
+-0.0509541	0.0617551	-0.99679	1000
+```
+
+**Legacy `.bvec` \& `.bval` specification of gradient information**.
 The `[*_]dwi.bval` and `[*_]dwi.bvec` files MUST follow the
 [FSL format](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FDT/UserGuide#DTIFIT):
 The `[*_]dwi.bvec` file contains 3 rows with *N* space-delimited floating-point numbers
@@ -555,8 +598,8 @@ Following the FSL format for the `[*_]dwi.bvec` specification, the coordinate sy
 the *b* vectors MUST be defined with respect to the coordinate system defined by
 the header of the corresponding `_dwi` NIfTI file and not the scanner's device
 coordinate system (see [Coordinate systems](../99-appendices/08-coordinate-systems.md)).
-The most relevant implication for this choice is that any rotations applied to the DWI data
-also need to be applied to the *b* vectors in the `[*_]dwi.bvec` file.
+The most relevant limitation imposed by this choice is that the gradient information cannot
+be directly stored in this format if the scanner generates *b*-vectors in *scanner coordinates*.
 
 Example of `[*_]dwi.bvec` file, with *N*=6, with two *b*=0 volumes in the beginning:
 
@@ -573,27 +616,6 @@ Example of `[*_]dwi.bval` file, corresponding to the previous `[*_]dwi.bvec` exa
 
 ```Text
 0 0 2000 2000 1000 1000
-```
-
-**RASB+ format for gradient strength and orientation**.
-Gradient strength and orientation can be provided in a TSV file named, for example,
-`sub-01_acq-singleband_dwi.tsv` or `sub-01_acq-multiband_dwi.tsv`.
-This TSV file must contain the columns `R A S B`, where `R`, `A` and `S` contain a unit vector
-describing the gradient direction in scanner coordinates.
-The `B` column contains the *b*-value in (in s/mm<sup>2</sup>).
-Although the *b*-value is a common way to convey gradient
-strength, it does not unambiguously depict the sampled coordinate in *q*-space.
-The relationship between each row of this TSV file and its corresponding *q*-space coordinate
-can be calculated with the `BigDelta` and `SmallDelta` metadata fields in the corresponding
-JSON file.
-
-Optional `dwi.tsv` example:
-
-```Text
-R	A	S	B
-0	0	0	0
-1.0	0	0	1000
--0.0509541      0.0617551       -0.99679        1000
 ```
 
 ### Multipart (split) DWI schemes
@@ -682,6 +704,12 @@ See [Common metadata fields](#common-metadata-fields) for a list of
 additional terms that can be included in the corresponding JSON file.
 
 #### Pulse gradient timing information
+
+Although the *b*-value is the most common way to convey gradient strength, it does not
+unambiguously depict the sampled coordinate in *q*-space.
+The relationship between each *b*-vector and its corresponding *q*-space coordinate
+can be calculated with the `BigDelta` and `SmallDelta` metadata fields in the corresponding
+JSON file.
 
 | Field name     | Definition                                                                                                                                                                                                                                                                |
 | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
+++ b/src/04-modality-specific-files/01-magnetic-resonance-imaging-data.md
@@ -598,8 +598,8 @@ Following the FSL format for the `[*_]dwi.bvec` specification, the coordinate sy
 the *b* vectors MUST be defined with respect to the coordinate system defined by
 the header of the corresponding `_dwi` NIfTI file and not the scanner's device
 coordinate system (see [Coordinate systems](../99-appendices/08-coordinate-systems.md)).
-The most relevant limitation imposed by this choice is that the gradient information cannot
-be directly stored in this format if the scanner generates *b*-vectors in *scanner coordinates*.
+The most relevant implication for this choice is that any rotations applied to the DWI data
+also need to be applied to the *b* vectors in the `[*_]dwi.bvec` file.
 
 Example of `[*_]dwi.bvec` file, with *N*=6, with two *b*=0 volumes in the beginning:
 


### PR DESCRIPTION
I have re-thinking about this and we probably want to be more liberal and instead of enforcing RAS+b, recommend storing anything the scanner spits out (i.e., allow IJK+b).

LMKWYT